### PR TITLE
chore: update to latest AGB

### DIFF
--- a/crabioware/Cargo.lock
+++ b/crabioware/Cargo.lock
@@ -10,44 +10,43 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "agb"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15841435cd041b2c78a6676d40afcc3a9d5ca7370242a533a4d018ac2795e794"
+version = "0.20.5"
+source = "git+https://github.com/agbrs/agb?branch=master#7a2ef4338c00673ec896aec42c49c8cd764b11ba"
 dependencies = [
  "agb_fixnum",
  "agb_hashmap",
  "agb_image_converter",
  "agb_macros",
  "agb_sound_converter",
- "bare-metal",
  "bilge",
  "bitflags 2.4.2",
+ "critical-section",
+ "once_cell",
+ "portable-atomic",
+ "qrcodegen-no-heap",
 ]
 
 [[package]]
 name = "agb_fixnum"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb6bf8653e1e330926b27b1a4fa273c03df0bbefd665701a7e9f301849bb4c7"
+version = "0.20.5"
+source = "git+https://github.com/agbrs/agb?branch=master#7a2ef4338c00673ec896aec42c49c8cd764b11ba"
 dependencies = [
  "agb_macros",
- "num",
+ "num-traits",
 ]
 
 [[package]]
 name = "agb_hashmap"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10059c4f6689aa922c875f15f06c1f13fa449d116476025b4527172a2b8207c3"
+version = "0.20.5"
+source = "git+https://github.com/agbrs/agb?branch=master#7a2ef4338c00673ec896aec42c49c8cd764b11ba"
 dependencies = [
  "rustc-hash",
 ]
 
 [[package]]
 name = "agb_image_converter"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0adbc7fe469dcf6fa2646eadf710688a0817fdd9caa805b21c9c74dcbaf4401e"
+version = "0.20.5"
+source = "git+https://github.com/agbrs/agb?branch=master#7a2ef4338c00673ec896aec42c49c8cd764b11ba"
 dependencies = [
  "asefile",
  "fontdue",
@@ -59,9 +58,8 @@ dependencies = [
 
 [[package]]
 name = "agb_macros"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f0d71d3b51ba69b91b475668beaa2f0216bb83e1562b04ff13bccc7d3bf68e"
+version = "0.20.5"
+source = "git+https://github.com/agbrs/agb?branch=master#7a2ef4338c00673ec896aec42c49c8cd764b11ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -70,9 +68,8 @@ dependencies = [
 
 [[package]]
 name = "agb_sound_converter"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac8f31cbf67a583d4869a45dc389e129bce87f0bb197faedabfff33efe0295f"
+version = "0.20.5"
+source = "git+https://github.com/agbrs/agb?branch=master#7a2ef4338c00673ec896aec42c49c8cd764b11ba"
 dependencies = [
  "hound",
  "proc-macro2",
@@ -143,12 +140,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "bare-metal"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
 name = "bilge"
@@ -281,6 +272,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
+
+[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "fontdue"
-version = "0.8.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9099a2f86b8e674b75d03ff154b3fe4c5208ed249ced8d69cc313a9fa40bb488"
+checksum = "efe23d02309319171d00d794c9ff48d4f903c0e481375b1b04b017470838af04"
 dependencies = [
  "hashbrown 0.14.3",
  "ttf-parser",
@@ -417,59 +414,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0f889fb66f7acdf83442c35775764b51fed3c606ab9cee51500dbde2cf528ca"
 
 [[package]]
-name = "num"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135b08af27d103b0a51f2ae0f8632117b7b185ccf931445affa8df530576a41"
-dependencies = [
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +427,10 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "png"
@@ -496,6 +444,12 @@ dependencies = [
  "flate2",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "proc-macro-error"
@@ -528,6 +482,12 @@ checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "qrcodegen-no-heap"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0e2c0bf8be8a1c4a4f48973dabf26943f05da2bfc2d3180aae62409dbba6f0c"
 
 [[package]]
 name = "quote"
@@ -609,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "ttf-parser"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
+checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
 
 [[package]]
 name = "unicode-ident"

--- a/crabioware/Cargo.toml
+++ b/crabioware/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.dependencies]
-agb = "^0.19.1"
+agb = { git = "https://github.com/agbrs/agb", branch = "master" }
 itertools = { version = "0.12.1", default-features = false }
 
 [workspace.package]

--- a/crabioware/crates/crabioware-core/src/screens/graphics.rs
+++ b/crabioware/crates/crabioware-core/src/screens/graphics.rs
@@ -4,13 +4,13 @@ use agb::{
 };
 
 // Graphics assets
-const SPRITES: &Graphics = include_aseprite!("assets/common.aseprite");
-const GAMEOVER: &Tag = SPRITES.tags().get("gameover");
-const VICTORY: &Tag = SPRITES.tags().get("victory");
-const PAUSE: &Tag = SPRITES.tags().get("pause");
-const PONG: &Tag = SPRITES.tags().get("pong");
-const SNAKE: &Tag = SPRITES.tags().get("snake");
-const PACCRAB: &Tag = SPRITES.tags().get("paccrab");
+static SPRITES: &Graphics = include_aseprite!("assets/common.aseprite");
+static GAMEOVER: &Tag = SPRITES.tags().get("gameover");
+static VICTORY: &Tag = SPRITES.tags().get("victory");
+static PAUSE: &Tag = SPRITES.tags().get("pause");
+static PONG: &Tag = SPRITES.tags().get("pong");
+static SNAKE: &Tag = SPRITES.tags().get("snake");
+static PACCRAB: &Tag = SPRITES.tags().get("paccrab");
 
 pub enum SpriteTag {
     GameOver,

--- a/crabioware/crates/crabioware-core/src/screens/start.rs
+++ b/crabioware/crates/crabioware-core/src/screens/start.rs
@@ -1,5 +1,3 @@
-use core::borrow::Borrow;
-
 use agb::display::object::{OamIterator, OamUnmanaged, ObjectUnmanaged, SpriteLoader};
 use agb::display::tiled::VRamManager;
 use agb::input::{Button, ButtonController};

--- a/crabioware/crates/games/paccrab/src/graphics.rs
+++ b/crabioware/crates/games/paccrab/src/graphics.rs
@@ -4,12 +4,12 @@ use agb::{
 };
 
 // Graphics assets
-const SPRITES: &Graphics = include_aseprite!("assets/sprites.aseprite");
-const CRAB: &Tag = SPRITES.tags().get("crab");
-const GHOST_PINK: &Tag = SPRITES.tags().get("pink");
-const GHOST_YELLOW: &Tag = SPRITES.tags().get("yellow");
-const GHOST_BLUE: &Tag = SPRITES.tags().get("blue");
-const BERRY: &Tag = SPRITES.tags().get("berry");
+static SPRITES: &Graphics = include_aseprite!("assets/sprites.aseprite");
+static CRAB: &Tag = SPRITES.tags().get("crab");
+static GHOST_PINK: &Tag = SPRITES.tags().get("pink");
+static GHOST_YELLOW: &Tag = SPRITES.tags().get("yellow");
+static GHOST_BLUE: &Tag = SPRITES.tags().get("blue");
+static BERRY: &Tag = SPRITES.tags().get("berry");
 
 pub enum SpriteTag {
     Crab,

--- a/crabioware/crates/games/paccrab/src/levels.rs
+++ b/crabioware/crates/games/paccrab/src/levels.rs
@@ -14,8 +14,8 @@ pub struct Level {
     pub warps: &'static [(i32, i32)],
 }
 impl Level {
-    pub fn get_tileset(&self) -> TileSet<'_> {
-        tile_sheet::tiles.tiles
+    pub fn get_tileset(&self) -> &TileSet<'_> {
+        &tile_sheet::tiles.tiles
     }
 
     pub fn get_tilesetting(&self, idx: usize) -> TileSetting {

--- a/crabioware/crates/games/pong/src/graphics.rs
+++ b/crabioware/crates/games/pong/src/graphics.rs
@@ -5,10 +5,10 @@ use agb::{
 };
 
 // Graphics assets
-const SPRITES: &Graphics = include_aseprite!("assets/sprites.aseprite");
-const PADDLE: &Tag = SPRITES.tags().get("paddle");
-const BALL: &Tag = SPRITES.tags().get("crab");
-const NUMBERS: &Tag = include_aseprite!("assets/numbers.aseprite")
+static SPRITES: &Graphics = include_aseprite!("assets/sprites.aseprite");
+static PADDLE: &Tag = SPRITES.tags().get("paddle");
+static BALL: &Tag = SPRITES.tags().get("crab");
+static NUMBERS: &Tag = include_aseprite!("assets/numbers.aseprite")
     .tags()
     .get("white");
 

--- a/crabioware/crates/games/snake/src/graphics.rs
+++ b/crabioware/crates/games/snake/src/graphics.rs
@@ -5,11 +5,11 @@ use agb::{
 };
 
 // Graphics assets
-const SPRITES: &Graphics = include_aseprite!("assets/sprites.aseprite");
-const SNAKE: &Tag = SPRITES.tags().get("green");
-const BERRY: &Tag = SPRITES.tags().get("red");
+static SPRITES: &Graphics = include_aseprite!("assets/sprites.aseprite");
+static SNAKE: &Tag = SPRITES.tags().get("green");
+static BERRY: &Tag = SPRITES.tags().get("red");
 // FIXME: more nutritious purple berries
-const NUMBERS: &Tag = include_aseprite!("assets/numbers.aseprite")
+static NUMBERS: &Tag = include_aseprite!("assets/numbers.aseprite")
     .tags()
     .get("white");
 


### PR DESCRIPTION
* Fixes build issue on latest Rust nightly
* Use static instead of const (prevents asset data from being included multiple times)